### PR TITLE
increase memory limit on workshops that were OOMKilled

### DIFF
--- a/workshops/04-test-first/resources/workshop.yaml
+++ b/workshops/04-test-first/resources/workshop.yaml
@@ -46,7 +46,7 @@ spec:
     namespaces:
       budget: medium
     resources:
-      memory: 2Gi
+      memory: 3Gi
     applications:
       terminal:
         enabled: true

--- a/workshops/05-first-rest-endpoint/resources/workshop.yaml
+++ b/workshops/05-first-rest-endpoint/resources/workshop.yaml
@@ -46,7 +46,7 @@ spec:
     namespaces:
       budget: medium
     resources:
-      memory: 2Gi
+      memory: 3Gi
     applications:
       terminal:
         enabled: true

--- a/workshops/06-spring-data/resources/workshop.yaml
+++ b/workshops/06-spring-data/resources/workshop.yaml
@@ -45,7 +45,7 @@ spec:
     namespaces:
       budget: medium
     resources:
-      memory: 2Gi
+      memory: 3Gi
     applications:
       terminal:
         enabled: true

--- a/workshops/07-create-post/resources/workshop.yaml
+++ b/workshops/07-create-post/resources/workshop.yaml
@@ -45,7 +45,7 @@ spec:
     namespaces:
       budget: medium
     resources:
-      memory: 2Gi
+      memory: 3Gi
     applications:
       terminal:
         enabled: true

--- a/workshops/09-simple-spring-security/resources/workshop.yaml
+++ b/workshops/09-simple-spring-security/resources/workshop.yaml
@@ -54,4 +54,4 @@ spec:
       - name: Editor
       - name: Terminal
     resources:
-      memory: 2Gi
+      memory: 3Gi


### PR DESCRIPTION
This increases the memory limit any workshops that were getting `OOMKilled`, most likely due the newer version of Educates consuming more memory in the base image than before.